### PR TITLE
Fix websockets crash

### DIFF
--- a/source-record.c
+++ b/source-record.c
@@ -924,6 +924,24 @@ static void source_record_filter_tick(void *data, float seconds)
 	width += (width & 1);
 	uint32_t height = obs_source_get_height(parent);
 	height += (height & 1);
+
+	if (width == 0 || height == 0) {
+		if (context->fileOutput) {
+			run_queued(stop_output_task, context->fileOutput);
+			context->fileOutput = NULL;
+		}
+		if (context->streamOutput) {
+			run_queued(stop_output_task, context->streamOutput);
+			context->streamOutput = NULL;
+		}
+		if (context->replayOutput) {
+			run_queued(stop_output_task, context->replayOutput);
+			context->replayOutput = NULL;
+		}
+		context->output_active = false;
+		return;
+	}
+
 	if (context->width != width || context->height != height || (!context->video_output && width && height)) {
 		struct obs_video_info ovi = {0};
 		obs_get_video_info(&ovi);

--- a/source-record.c
+++ b/source-record.c
@@ -250,7 +250,11 @@ static void start_stream_output_task(void *data)
 
 void release_output_stopped(void *data, calldata_t *cd)
 {
-	UNUSED_PARAMETER(cd);
+	obs_output_t *output = data;
+	signal_handler_t *sh = obs_output_get_signal_handler(output);
+	if (sh)
+		signal_handler_disconnect(sh, "stop", release_output_stopped, output);
+
 	run_queued((obs_task_t)obs_output_release, data);
 }
 


### PR DESCRIPTION
There is a race condition when the stop signal handler is called. Since it is never unregistered, it can be called twice: once from UI thread and once from Graphics thread, which leads to double-free error.

Another bug is caused by switching the recorded source's visibility off and on: in this case the plugin tries to create an encoder with width=0 and height=0, which fails, and the plugin goes into a weird inconsistent state. This fix solves that problem a little bit.